### PR TITLE
Remove BDM benchmark option for faster GHA

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -46,6 +46,7 @@ jobs:
         cd biodynamo
         cmake -G Ninja \
           -Dparaview=on \
+          -Dbenchmark=off \
           -DCMAKE_BUILD_TYPE=Release \
           -B build
         cmake --build build --parallel --config Release

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -54,13 +54,13 @@ jobs:
         cd biodynamo
         cmake -G Ninja \
           -Dparaview=on \
+          -Dbenchmark=off \
           -DCMAKE_BUILD_TYPE=Release \
           -B build
         cmake --build build --parallel --config Release
 
     - name: Build flocking_simulation and run small simulation
       run: |
-        sed -i 's/"export_visualization": true/"export_visualization": false/g' bdm.json
         . ../biodynamo/build/bin/thisbdm.sh
         cmake -G Ninja -B build
         cmake --build build --parallel --config Release


### PR DESCRIPTION
Don't compile BioDynaMo with the benchmarking feature to speed up GHA.