### PR TITLE
No mechanical forces

### DIFF
--- a/bdm.json
+++ b/bdm.json
@@ -31,10 +31,10 @@
     "max_force": 1.5,
     "max_speed": 8,
     "min_speed": 3,
-    "crusing_speed": 4,
+    "cruising_speed": 4,
     "cohesion_weight": 1,
     "alignment_weight": 2,
-    "seperation_weight": 1.5,
+    "separation_weight": 1.5,
     "avoid_domain_boundary_weight": 10,
     "obstacle_avoidance_weight": 20,
     "simulation_steps": 500

--- a/bdm.json
+++ b/bdm.json
@@ -10,6 +10,9 @@
     "simulation_time_step": 0.01,
     "visualization_interval": 1,
     "export_visualization": true,
+    "unschedule_default_operations": [
+      "mechanical forces"
+    ],
     "visualize_agents": {
       "Boid": [
         "actual_diameter_"

--- a/src/boid.cc
+++ b/src/boid.cc
@@ -19,11 +19,11 @@ void Boid::InitializeMembers() {
   SetPerceptionAngle(perception_angle_rad);
   max_force_ = sparam->max_force;
   max_speed_ = sparam->max_speed;
-  crusing_speed_ = sparam->crusing_speed;
+  cruising_speed_ = sparam->cruising_speed;
   min_speed_ = sparam->min_speed;
   cohesion_weight_ = sparam->cohesion_weight;
   alignment_weight_ = sparam->alignment_weight;
-  seperation_weight_ = sparam->seperation_weight;
+  separation_weight_ = sparam->separation_weight;
   avoid_domain_boundary_weight_ = sparam->avoid_domain_boundary_weight;
   obstacle_avoidance_weight_ = sparam->obstacle_avoidance_weight;
   obst_avoid_dist_ = sparam->obst_avoid_dist;
@@ -185,7 +185,7 @@ Double3 Boid::SteerTowards(Double3 vector) {
   if (vector.Norm() == 0) {
     return {0, 0, 0};
   }
-  Double3 steer = vector.Normalize() * crusing_speed_ - velocity_;
+  Double3 steer = vector.Normalize() * cruising_speed_ - velocity_;
   return UpperLimit(steer, max_force_);
 }
 
@@ -472,11 +472,9 @@ double Boid::phi_h(double z, double h) {
   return 0;
 }
 
-double Boid::sigmoid_1(double z) {
-  return z / std::sqrt(1 + z * z); }
+double Boid::sigmoid_1(double z) { return z / std::sqrt(1 + z * z); }
 
-double Boid::sigmoid_2(double z) {
-  return z / (1 + std::abs(z)); }
+double Boid::sigmoid_2(double z) { return z / (1 + std::abs(z)); }
 
 double Boid::Phi_a(double z) {
   // r_a and d_a sometimes get initialzied as nan, so as a temp fix always
@@ -522,9 +520,7 @@ Double3 Boid::GetSphereInteractionTerm(Double3 centre_, double radius_) {
   // second term
   double r_a = Norm_sig(obstacle_distance_);
   double b_ik = phi_h(Norm_sig(q_ik - GetPosition()) / r_a, 0.9);
-  u_b +=
-      (GetProjectedVelocity(centre_, radius_) - GetVelocity()) *
-      b_ik;
+  u_b += (GetProjectedVelocity(centre_, radius_) - GetVelocity()) * b_ik;
 
   return u_b;
 };
@@ -559,7 +555,7 @@ void Flocking::Run(Agent* agent) {
   // Update acceleration_, new_velocity_, new_position_ of boid
   boid->ResetAcceleration();
 
-  boid->AccelerationAccumulator(seperation_force * boid->seperation_weight_);
+  boid->AccelerationAccumulator(seperation_force * boid->separation_weight_);
   boid->AccelerationAccumulator(cohesion_force * boid->cohesion_weight_);
   // boid->AccelerationAccumulator(social_force * 5);
   boid->AccelerationAccumulator(alignment_force * boid->alignment_weight_);

--- a/src/boid.h
+++ b/src/boid.h
@@ -69,7 +69,7 @@ class Boid : public Cell {
   Double3 AvoidDomainBoundary();
 
   // Returns a Steering-Force in order to steer velocity towards
-  // (vector.Normalize() * crusing_speed_)
+  // (vector.Normalize() * cruising_speed_)
   // Force is limited by max_force_
   Double3 SteerTowards(Double3 vector);
 
@@ -156,8 +156,8 @@ class Boid : public Cell {
          neighbor_distance_ = 40, obst_avoid_dist_ = 100,
          obstacle_distance_ = 40, perception_angle_ = M_PI;
   double cos_perception_angle_;
-  double max_force_ = 3, max_speed_ = 20, crusing_speed_ = 15, min_speed_ = 10;
-  double cohesion_weight_ = 1, alignment_weight_ = 2, seperation_weight_ = 1.5,
+  double max_force_ = 3, max_speed_ = 20, cruising_speed_ = 15, min_speed_ = 10;
+  double cohesion_weight_ = 1, alignment_weight_ = 2, separation_weight_ = 1.5,
          avoid_domain_boundary_weight_ = 25, obstacle_avoidance_weight_ = 10;
   static const std::vector<Double3> directions_;
   static const std::vector<Double3> cone_directions_;

--- a/src/sim_param.h
+++ b/src/sim_param.h
@@ -20,11 +20,11 @@ struct SimParam : public ParamGroup {
   double obstacle_distance = 40;
   double max_force = 3;
   double max_speed = 15;
-  double crusing_speed = 12;
+  double cruising_speed = 12;
   double min_speed = 0;
   double cohesion_weight = 1;
   double alignment_weight = 2;
-  double seperation_weight = 1.5;
+  double separation_weight = 1.5;
   double avoid_domain_boundary_weight = 25;
   double obstacle_avoidance_weight = 5;
   uint64_t simulation_steps = 10;


### PR DESCRIPTION
I just took a look at the runtime profile of your code and saw that when increasing the number of boids, BDM starts computing mechanical forces between them. This PR turns off the computation of the mechanical forces. Actually, this should not make any difference for your current simulation, since BDM only computes forces when agents overlap. But yes, let's better turn it off to not have undesired effects in the simulation.