### PR TITLE
Fix GHA with `CNPY` installation

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     
-    - name: Checkout HIV_malawi repository
+    - name: Checkout BDM-FLOCKING-SIMULATION repository
       uses: actions/checkout@v2
     
     - name: Make sure Xcode 12.4 is used on macOS 10.15 as the default /Application/Xcode.app
@@ -51,6 +51,15 @@ jobs:
           -B build
         cmake --build build --parallel --config Release
 
+    - name: Install CNPY
+      run: |
+        cd ..
+        git clone https://github.com/rogersce/cnpy.git
+        cd cnpy
+        mkdir build && cd build
+        cmake .. && make -j4
+        sudo make install
+        
     - name: Build flocking_simulation and run small simulation
       run: |
         . ../biodynamo/build/bin/thisbdm.sh

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -59,6 +59,15 @@ jobs:
           -B build
         cmake --build build --parallel --config Release
 
+    - name: Install CNPY
+      run: |
+        cd ..
+        git clone https://github.com/rogersce/cnpy.git
+        cd cnpy
+        mkdir build && cd build
+        cmake .. && make -j4
+        sudo make install
+
     - name: Build flocking_simulation and run small simulation
       run: |
         . ../biodynamo/build/bin/thisbdm.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,15 @@ include(${BDM_USE_FILE})
 # Load CNPY
 set(CNPY_PATH "/usr/local/include") # PATH to source directore, e.g. cloned git
 set(CNPY_LIB "/usr/local/lib") # PATH to installed directory
+if(APPLE)
+  set(CNPY_LIB_NAME "libcnpy.dylib")
+else()
+  set(CNPY_LIB_NAME "libcnpy.so")
+endif(APPLE)
 include_directories(${CNPY_PATH})
 add_library(cnpy SHARED IMPORTED)
 set_target_properties(cnpy PROPERTIES
-  IMPORTED_LOCATION "${CNPY_LIB}/libcnpy.so"
+  IMPORTED_LOCATION "${CNPY_LIB}/${CNPY_LIB_NAME}"
   INTERFACE_INCLUDE_DIRECTORIES "${CNPY_PATH}"
 )
 


### PR DESCRIPTION
This PR fixes the GHA. It installs the `CNPY` dependency on Ubuntu and macOS. Furthermore, it now chooses the correct library names for macOS and Ubuntu in the `CMakeLists.txt`.